### PR TITLE
Add support for custom Prettier config

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -9,26 +9,31 @@ module.exports = ({ testPath, config, globalConfig }) => {
   const start = new Date();
   const contents = fs.readFileSync(testPath, "utf8");
 
-  const isPretty = prettier.check(contents, { filepath: testPath });
+  return prettier.resolveConfig(testPath).then(config => {
+    const prettierConfig = Object.assign({}, config, {
+      filepath: testPath
+    });
 
-  if (isPretty) {
-    return pass({
+    const isPretty = prettier.check(contents, prettierConfig);
+    if (isPretty) {
+      return pass({
+        start,
+        end: new Date(),
+        test: { path: testPath }
+      });
+    }
+
+    const formatted = prettier.format(contents, prettierConfig);
+
+    return fail({
       start,
       end: new Date(),
-      test: { path: testPath }
+      test: {
+        path: testPath,
+        errorMessage: diff(highlight(formatted), highlight(contents), {
+          expand: false
+        })
+      }
     });
-  }
-
-  const formatted = prettier.format(contents, { filepath: testPath });
-
-  return fail({
-    start,
-    end: new Date(),
-    test: {
-      path: testPath,
-      errorMessage: diff(highlight(formatted), highlight(contents), {
-        expand: false
-      })
-    }
   });
 };

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -16,13 +16,13 @@ expect.addSnapshotSerializer({
 
 const snapShotTest = fileName => () => {
   it("matches snapshot", () => {
-    const result = run({
+    return run({
       testPath: path.join(__dirname, "__fixtures__", fileName),
       config: {},
       globalConfig: {}
+    }).then(result => {
+      expect(result).toMatchSnapshot();
     });
-
-    expect(result).toMatchSnapshot();
   });
 };
 


### PR DESCRIPTION
Hi! I just ran across your tool on Twitter and it seemed useful, so I decided to try it out. I added it to a project of mine and ran `yarn test` on a codebase already using Prettier and unexpectedly got lots of errors. I figured it might've been due to a custom Prettier config (single quotes & trailing commas), so I added a `.prettierrc` file to my project, expecting `jest-runner-prettier` to pick it up automatically. When it didn't, I decided to see if I could fix this, and here we are.

What I did:
- Added a call to [`prettier.resolveConfig`](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath-options) in order to check for a user-defined Prettier config. This function returns a promise, which [`create-jest-runner`](https://github.com/Rogeliog/create-jest-runner#run-file-api) thankfully supports.
- Updated `prettier.check` and `prettier.format` calls to use the previously fetched config.

Potential issues/things that I can improve as requested:
- I used `Object.assign` to merge the config objects. It's supported by Node.js 4+ so it should be fine.
- I updated the tests to work with the new promise returned, but didn't write any new tests. Technically, we should be able to trust that prettier does resolve a config object if there is one, but I'm fine with adding a sanity check here.
- When I created a commit, it failed. I'm not familiar with the commit linter so I wasn't entirely sure how to fix that. Happy to rebase with what you think is appropriate.

Thanks for building this! I'd love to use this in my personal projects and at work, once this issue has been resolved (whether by this PR or not).