### PR TITLE
feat(config): respect a new custom config value: jestRunnerWrite

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -24,6 +24,11 @@ module.exports = ({ testPath }) => {
 
     const formatted = prettier.format(contents, prettierConfig);
 
+    // a custom config value that is only used by jest-runner-prettier
+    if (prettierConfig.jestRunnerWrite) {
+      fs.writeFileSync(testPath, formatted, "utf8");
+    }
+
     return fail({
       start,
       end: new Date(),


### PR DESCRIPTION
when `jestRunnerWrite: true` is added to `prettier.config.js`, then `jest-runner-prettier` will write files in place. this is necessary because prettier does not currently let users specify `write: true` in their config.