### PR TITLE
fix: require jest diff properly for version 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ or `jest.config.js`:
 
 ```js
 module.exports = {
-  preset: "jest-runner-prettier"
+  preset: "jest-runner-prettier",
 };
 ```
 
@@ -126,7 +126,7 @@ module.exports = {
     "markdown",
     "mdx",
     "yaml",
-    "yml"
+    "yml",
   ],
   testMatch: [
     "**/*.js",
@@ -145,8 +145,8 @@ module.exports = {
     "**/*.markdown",
     "**/*.mdx",
     "**/*.yaml",
-    "**/*.yml"
-  ]
+    "**/*.yml",
+  ],
 };
 ```
 

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -17,7 +17,7 @@ module.exports = {
     "markdown",
     "mdx",
     "yaml",
-    "yml"
+    "yml",
   ],
   testMatch: [
     "**/*.js",
@@ -36,6 +36,6 @@ module.exports = {
     "**/*.markdown",
     "**/*.mdx",
     "**/*.yaml",
-    "**/*.yml"
-  ]
+    "**/*.yml",
+  ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
     {
       collectCoverage: true,
       coverageReporters: ["json", "text"],
-      displayName: "test"
+      displayName: "test",
     },
     {
       preset: "./jest-preset.js",
@@ -14,13 +14,13 @@ module.exports = {
       testPathIgnorePatterns: [
         "/node_modules/",
         "/src/__fixtures__/",
-        "/coverage/"
-      ]
+        "/coverage/",
+      ],
     },
     {
       runner: "eslint",
       displayName: "lint:eslint",
-      testMatch: ["<rootDir>/**/*.js"]
-    }
-  ]
+      testMatch: ["<rootDir>/**/*.js"],
+    },
+  ],
 };

--- a/src/__fixtures__/good.jsx
+++ b/src/__fixtures__/good.jsx
@@ -2,7 +2,7 @@ function HelloWorld({
   greeting = "hello",
   greeted = '"World"',
   silent = false,
-  onMouseOver
+  onMouseOver,
 }) {
   if (!greeting) {
     return null;

--- a/src/__snapshots__/run.test.js.snap
+++ b/src/__snapshots__/run.test.js.snap
@@ -7,25 +7,25 @@ Object {
 [31m+ Received[39m
 
 [32m- {[39m
-[32m-   [36m\\"ohMyGodLongArray\\"[32m: [[39m
-[32m-     [31m\\"prettyLongValue\\"[32m,[39m
-[32m-     [31m\\"decentlyLongValue\\"[32m,[39m
-[32m-     [31m\\"prettyDecentlyLongValue\\"[32m,[39m
-[32m-     [31m\\"wowWowWowWhatALongValue\\"[32m[39m
+[32m-   [36m\\"ohMyGodLongArray\\"[39m[32m: [[39m
+[32m-     [31m\\"prettyLongValue\\"[39m[32m,[39m
+[32m-     [31m\\"decentlyLongValue\\"[39m[32m,[39m
+[32m-     [31m\\"prettyDecentlyLongValue\\"[39m[32m,[39m
+[32m-     [31m\\"wowWowWowWhatALongValue\\"[39m[32m[39m
 [32m-   ],[39m
-[32m-   [36m\\"woahThisObjectIsDisapperingOffTheScreen\\"[32m: {[39m
-[32m-     [36m\\"foo\\"[32m: [31m\\"bar\\"[32m,[39m
-[32m-     [36m\\"bar\\"[32m: [31m\\"foo\\"[32m,[39m
-[32m-     [36m\\"faz\\"[32m: [34mfalse[32m[39m
+[32m-   [36m\\"woahThisObjectIsDisapperingOffTheScreen\\"[39m[32m: {[39m
+[32m-     [36m\\"foo\\"[39m[32m: [31m\\"bar\\"[39m[32m,[39m
+[32m-     [36m\\"bar\\"[39m[32m: [31m\\"foo\\"[39m[32m,[39m
+[32m-     [36m\\"faz\\"[39m[32m: [34mfalse[39m[32m[39m
 [32m-   },[39m
-[32m-   [36m\\"truthy\\"[32m: [34mtrue[32m,[39m
-[32m-   [36m\\"aNumber\\"[32m: [32m123[32m,[39m
-[32m-   [36m\\"aString\\"[32m: [31m\\"hi\\"[32m[39m
+[32m-   [36m\\"truthy\\"[39m[32m: [34mtrue[39m[32m,[39m
+[32m-   [36m\\"aNumber\\"[39m[32m: [32m123[39m[32m,[39m
+[32m-   [36m\\"aString\\"[39m[32m: [31m\\"hi\\"[39m[32m[39m
 [32m- }[39m
-[32m- [39m
-[31m+ {[36m\\"ohMyGodLongArray\\"[31m: [[31m\\"prettyLongValue\\"[31m, [31m\\"decentlyLongValue\\"[31m,[39m
-[31m+   [31m\\"prettyDecentlyLongValue\\"[31m, [31m\\"wowWowWowWhatALongValue\\"[31m], [36m\\"woahThisObjectIsDisapperingOffTheScreen\\"[31m: {[36m\\"foo\\"[31m: [31m\\"bar\\"[31m,[39m
-[31m+     [36m\\"bar\\"[31m: [31m\\"foo\\"[31m, [36m\\"faz\\"[31m: [34mfalse[31m}, [36m\\"truthy\\"[31m: [34mtrue[31m, [36m\\"aNumber\\"[31m: [32m123[31m, [36m\\"aString\\"[31m: [31m\\"hi\\"[31m[39m
+[32m-[39m
+[31m+ {[36m\\"ohMyGodLongArray\\"[39m[31m: [[31m\\"prettyLongValue\\"[39m[31m, [31m\\"decentlyLongValue\\"[39m[31m,[39m
+[31m+   [31m\\"prettyDecentlyLongValue\\"[39m[31m, [31m\\"wowWowWowWhatALongValue\\"[39m[31m], [36m\\"woahThisObjectIsDisapperingOffTheScreen\\"[39m[31m: {[36m\\"foo\\"[39m[31m: [31m\\"bar\\"[39m[31m,[39m
+[31m+     [36m\\"bar\\"[39m[31m: [31m\\"foo\\"[39m[31m, [36m\\"faz\\"[39m[31m: [34mfalse[39m[31m}, [36m\\"truthy\\"[39m[31m: [34mtrue[39m[31m, [36m\\"aNumber\\"[39m[31m: [32m123[39m[31m, [36m\\"aString\\"[39m[31m: [31m\\"hi\\"[39m[31m[39m
 [31m+   }[39m",
   "numFailingTests": 1,
   "numPassingTests": 0,
@@ -50,25 +50,25 @@ Object {
 [31m+ Received[39m
 
 [32m- {[39m
-[32m-   [36m\\"ohMyGodLongArray\\"[32m: [[39m
-[32m-     [31m\\"prettyLongValue\\"[32m,[39m
-[32m-     [31m\\"decentlyLongValue\\"[32m,[39m
-[32m-     [31m\\"prettyDecentlyLongValue\\"[32m,[39m
-[32m-     [31m\\"wowWowWowWhatALongValue\\"[32m[39m
+[32m-   [36m\\"ohMyGodLongArray\\"[39m[32m: [[39m
+[32m-     [31m\\"prettyLongValue\\"[39m[32m,[39m
+[32m-     [31m\\"decentlyLongValue\\"[39m[32m,[39m
+[32m-     [31m\\"prettyDecentlyLongValue\\"[39m[32m,[39m
+[32m-     [31m\\"wowWowWowWhatALongValue\\"[39m[32m[39m
 [32m-   ],[39m
-[32m-   [36m\\"woahThisObjectIsDisapperingOffTheScreen\\"[32m: {[39m
-[32m-     [36m\\"foo\\"[32m: [31m\\"bar\\"[32m,[39m
-[32m-     [36m\\"bar\\"[32m: [31m\\"foo\\"[32m,[39m
-[32m-     [36m\\"faz\\"[32m: [34mfalse[32m[39m
+[32m-   [36m\\"woahThisObjectIsDisapperingOffTheScreen\\"[39m[32m: {[39m
+[32m-     [36m\\"foo\\"[39m[32m: [31m\\"bar\\"[39m[32m,[39m
+[32m-     [36m\\"bar\\"[39m[32m: [31m\\"foo\\"[39m[32m,[39m
+[32m-     [36m\\"faz\\"[39m[32m: [34mfalse[39m[32m[39m
 [32m-   },[39m
-[32m-   [36m\\"truthy\\"[32m: [34mtrue[32m,[39m
-[32m-   [36m\\"aNumber\\"[32m: [32m123[32m,[39m
-[32m-   [36m\\"aString\\"[32m: [31m\\"hi\\"[32m[39m
+[32m-   [36m\\"truthy\\"[39m[32m: [34mtrue[39m[32m,[39m
+[32m-   [36m\\"aNumber\\"[39m[32m: [32m123[39m[32m,[39m
+[32m-   [36m\\"aString\\"[39m[32m: [31m\\"hi\\"[39m[32m[39m
 [32m- }[39m
-[32m- [39m
-[31m+ {[36m\\"ohMyGodLongArray\\"[31m: [[31m\\"prettyLongValue\\"[31m, [31m\\"decentlyLongValue\\"[31m,[39m
-[31m+   [31m\\"prettyDecentlyLongValue\\"[31m, [31m\\"wowWowWowWhatALongValue\\"[31m], [36m\\"woahThisObjectIsDisapperingOffTheScreen\\"[31m: {[36m\\"foo\\"[31m: [31m\\"bar\\"[31m,[39m
-[31m+     [36m\\"bar\\"[31m: [31m\\"foo\\"[31m, [36m\\"faz\\"[31m: [34mfalse[31m}, [36m\\"truthy\\"[31m: [34mtrue[31m, [36m\\"aNumber\\"[31m: [32m123[31m, [36m\\"aString\\"[31m: [31m\\"hi\\"[31m[39m
+[32m-[39m
+[31m+ {[36m\\"ohMyGodLongArray\\"[39m[31m: [[31m\\"prettyLongValue\\"[39m[31m, [31m\\"decentlyLongValue\\"[39m[31m,[39m
+[31m+   [31m\\"prettyDecentlyLongValue\\"[39m[31m, [31m\\"wowWowWowWhatALongValue\\"[39m[31m], [36m\\"woahThisObjectIsDisapperingOffTheScreen\\"[39m[31m: {[36m\\"foo\\"[39m[31m: [31m\\"bar\\"[39m[31m,[39m
+[31m+     [36m\\"bar\\"[39m[31m: [31m\\"foo\\"[39m[31m, [36m\\"faz\\"[39m[31m: [34mfalse[39m[31m}, [36m\\"truthy\\"[39m[31m: [34mtrue[39m[31m, [36m\\"aNumber\\"[39m[31m: [32m123[39m[31m, [36m\\"aString\\"[39m[31m: [31m\\"hi\\"[39m[31m[39m
 [31m+   }[39m",
       ],
       "fullName": undefined,
@@ -120,59 +120,59 @@ Object {
   "failureMessage": "[32m- Expected[39m
 [31m+ Received[39m
 
-[32m- [33m[34mfunction[32m[33m HelloWorld({[32m[39m
-[32m- [33m  greeting = [31m\\"hello\\"[32m[33m,[32m[39m
-[32m- [33m  greeted = [31m'\\"World\\"'[32m[33m,[32m[39m
-[32m- [33m  silent = false,[32m[39m
-[32m- [33m  onMouseOver[32m[39m
-[32m- [33m}) [32m{[39m
-[32m-   [34mif[32m (!greeting) {[39m
-[32m-     [34mreturn[32m [34mnull[32m;[39m
+[32m- [33m[34mfunction[39m[32m[33m HelloWorld({[39m[32m[39m
+[32m- [33m  greeting = [31m\\"hello\\"[39m[32m[33m,[39m[32m[39m
+[32m- [33m  greeted = [31m'\\"World\\"'[39m[32m[33m,[39m[32m[39m
+[32m- [33m  silent = [34mfalse[39m[32m[33m,[39m[32m[39m
+[32m- [33m  onMouseOver,[39m[32m[39m
+[32m- [33m}) [39m[32m{[39m
+[32m-   [34mif[39m[32m (!greeting) {[39m
+[32m-     [34mreturn[39m[32m [34mnull[39m[32m;[39m
 [32m-   }[39m
-[31m+ [33m[34mfunction[31m[33m HelloWorld({greeting = [31m\\"hello\\"[31m[33m, greeted = [31m'\\"World\\"'[31m[33m, silent = false, onMouseOver,}) [31m{[39m
-[31m+ [39m
-[31m+   [34mif[31m(!greeting){[34mreturn[31m [34mnull[31m};[39m
-[31m+ [39m
-[31m+      [32m// [32mTODO:[31m[32m Don't use random in render[31m[39m
-[31m+   [34mlet[31m num = [36mMath[31m.floor ([36mMath[31m.random() * [32m1E+7[31m).toString().replace([31m/\\\\.\\\\d+/ig[31m, [31m\\"\\"[31m)[39m
-[31m+ [39m
-[31m+   [34mreturn[31m [90m<[34mdiv[31m[90m [36mclassName[31m[90m=[31m'HelloWorld'[31m[90m [36mtitle[31m[90m=[31m{[31m[90m\`[36mYou[31m[90m [36mare[31m[90m [36mvisitor[31m[90m [36mnumber[31m[90m \${ [36mnum[31m[90m }\`} [36monMouseOver[31m[90m=[31m{onMouseOver}[31m[90m>[31m[39m
-[31m+ [39m
-[31m+     [90m<[34mstrong[31m[90m>[31m{ greeting.slice( 0, 1 ).toUpperCase() + greeting.slice(1).toLowerCase() }[90m</[34mstrong[31m[90m>[31m[39m
-[31m+     {greeting.endsWith(\\",\\") ? \\" \\" : [90m<[34mspan[31m[90m [36mstyle[31m[90m=[31m{{color:[31m[90m '\\\\[36mgrey[31m[90m'}}>[31m\\", \\"[90m</[34mspan[31m[90m>[31m }[39m
-[31m+     [90m<[34mem[31m[90m>[31m[39m
+[31m+ [33m[34mfunction[39m[31m[33m HelloWorld({greeting = [31m\\"hello\\"[39m[31m[33m, greeted = [31m'\\"World\\"'[39m[31m[33m, silent = [34mfalse[39m[31m[33m, onMouseOver,}) [39m[31m{[39m
+[31m+[39m
+[31m+   [34mif[39m[31m(!greeting){[34mreturn[39m[31m [34mnull[39m[31m};[39m
+[31m+[39m
+[31m+      [32m// [32mTODO:[39m[31m[32m Don't use random in render[39m[31m[39m
+[31m+   [34mlet[39m[31m num = [36mMath[39m[31m.floor ([36mMath[39m[31m.random() * [32m1E+7[39m[31m).toString().replace([31m/\\\\.\\\\d+/ig[39m[31m, [31m\\"\\"[39m[31m)[39m
+[31m+[39m
+[31m+   [34mreturn[39m[31m [90m<[34mdiv[39m[31m[90m [36mclassName[39m[31m[90m=[31m'HelloWorld'[39m[31m[90m [36mtitle[39m[31m[90m=[31m{[39m[31m[90m\`[36mYou[39m[31m[90m [36mare[39m[31m[90m [36mvisitor[39m[31m[90m [36mnumber[39m[31m[90m \${ [36mnum[39m[31m[90m }\`} [36monMouseOver[39m[31m[90m=[31m{onMouseOver}[39m[31m[90m>[39m[31m[39m
+[31m+[39m
+[31m+     [90m<[34mstrong[39m[31m[90m>[39m[31m{ greeting.slice( 0, 1 ).toUpperCase() + greeting.slice(1).toLowerCase() }[90m</[34mstrong[39m[31m[90m>[39m[31m[39m
+[31m+     {greeting.endsWith(\\",\\") ? \\" \\" : [90m<[34mspan[39m[31m[90m [36mstyle[39m[31m[90m=[31m{{color:[39m[31m[90m '\\\\[36mgrey[39m[31m[90m'}}>[39m[31m\\", \\"[90m</[34mspan[39m[31m[90m>[39m[31m }[39m
+[31m+     [90m<[34mem[39m[31m[90m>[39m[31m[39m
 [31m+ 	{ greeted }[39m
-[31m+ 	[90m</[34mem[31m[90m>[31m[39m
+[31m+ 	[90m</[34mem[39m[31m[90m>[39m[31m[39m
 [31m+     { (silent)[39m
 [31m+       ? \\".\\"[39m
 [31m+       : \\"!\\"}[39m
-[2m  [22m
-[32m-   [32m// [32mTODO:[32m[32m Don't use random in render[32m[39m
-[32m-   [34mlet[32m num = [36mMath[32m.floor([36mMath[32m.random() * [32m1e7[32m)[39m
+
+[32m-   [32m// [32mTODO:[39m[32m[32m Don't use random in render[39m[32m[39m
+[32m-   [34mlet[39m[32m num = [36mMath[39m[32m.floor([36mMath[39m[32m.random() * [32m1e7[39m[32m)[39m
 [32m-     .toString()[39m
-[32m-     .replace([31m/\\\\.\\\\d+/gi[32m, [31m\\"\\"[32m);[39m
-[31m+     [90m</[34mdiv[31m[90m>[31m;[39m
-[2m  [22m
-[32m-   [34mreturn[32m ([39m
-[32m-     [90m<[34mdiv[32m[90m[32m[39m
-[32m- [90m      [36mclassName[32m[90m=[31m\\"HelloWorld\\"[32m[90m[32m[39m
-[32m- [90m      [36mtitle[32m[90m=[31m{[32m[90m\`[36mYou[32m[90m [36mare[32m[90m [36mvisitor[32m[90m [36mnumber[32m[90m \${[36mnum[32m[90m}\`}[32m[39m
-[32m- [90m      [36monMouseOver[32m[90m=[31m{onMouseOver}[32m[90m[32m[39m
-[32m- [90m    >[32m[39m
-[32m-       [90m<[34mstrong[32m[90m>[32m[39m
+[32m-     .replace([31m/\\\\.\\\\d+/gi[39m[32m, [31m\\"\\"[39m[32m);[39m
+[31m+     [90m</[34mdiv[39m[31m[90m>[39m[31m;[39m
+
+[32m-   [34mreturn[39m[32m ([39m
+[32m-     [90m<[34mdiv[39m[32m[90m[39m[32m[39m
+[32m- [90m      [36mclassName[39m[32m[90m=[31m\\"HelloWorld\\"[39m[32m[90m[39m[32m[39m
+[32m- [90m      [36mtitle[39m[32m[90m=[31m{[39m[32m[90m\`[36mYou[39m[32m[90m [36mare[39m[32m[90m [36mvisitor[39m[32m[90m [36mnumber[39m[32m[90m \${[36mnum[39m[32m[90m}\`}[39m[32m[39m
+[32m- [90m      [36monMouseOver[39m[32m[90m=[31m{onMouseOver}[39m[32m[90m[39m[32m[39m
+[32m- [90m    >[39m[32m[39m
+[32m-       [90m<[34mstrong[39m[32m[90m>[39m[32m[39m
 [32m-         {greeting.slice(0, 1).toUpperCase() + greeting.slice(1).toLowerCase()}[39m
-[32m-       [90m</[34mstrong[32m[90m>[32m[39m
+[32m-       [90m</[34mstrong[39m[32m[90m>[39m[32m[39m
 [32m-       {greeting.endsWith(\\",\\") ? ([39m
 [32m-         \\" \\"[39m
 [32m-       ) : ([39m
-[32m-         [90m<[34mspan[32m[90m [36mstyle[32m[90m=[31m{{[32m[90m [36mcolor:[32m[90m \\"[36mgrey[32m[90m\\" }}>[32m\\", \\"[90m</[34mspan[32m[90m>[32m[39m
+[32m-         [90m<[34mspan[39m[32m[90m [36mstyle[39m[32m[90m=[31m{{[39m[32m[90m [36mcolor:[39m[32m[90m \\"[36mgrey[39m[32m[90m\\" }}>[39m[32m\\", \\"[90m</[34mspan[39m[32m[90m>[39m[32m[39m
 [32m-       )}[39m
-[32m-       [90m<[34mem[32m[90m>[32m{greeted}[90m</[34mem[32m[90m>[32m[39m
+[32m-       [90m<[34mem[39m[32m[90m>[39m[32m{greeted}[90m</[34mem[39m[32m[90m>[39m[32m[39m
 [32m-       {silent ? \\".\\" : \\"!\\"}[39m
-[32m-     [90m</[34mdiv[32m[90m>[32m[39m
+[32m-     [90m</[34mdiv[39m[32m[90m>[39m[32m[39m
 [32m-   );[39m
 [2m  }[22m
-[32m- [39m",
+[32m-[39m",
   "numFailingTests": 1,
   "numPassingTests": 0,
   "numPendingTests": 0,
@@ -195,59 +195,59 @@ Object {
         "[32m- Expected[39m
 [31m+ Received[39m
 
-[32m- [33m[34mfunction[32m[33m HelloWorld({[32m[39m
-[32m- [33m  greeting = [31m\\"hello\\"[32m[33m,[32m[39m
-[32m- [33m  greeted = [31m'\\"World\\"'[32m[33m,[32m[39m
-[32m- [33m  silent = false,[32m[39m
-[32m- [33m  onMouseOver[32m[39m
-[32m- [33m}) [32m{[39m
-[32m-   [34mif[32m (!greeting) {[39m
-[32m-     [34mreturn[32m [34mnull[32m;[39m
+[32m- [33m[34mfunction[39m[32m[33m HelloWorld({[39m[32m[39m
+[32m- [33m  greeting = [31m\\"hello\\"[39m[32m[33m,[39m[32m[39m
+[32m- [33m  greeted = [31m'\\"World\\"'[39m[32m[33m,[39m[32m[39m
+[32m- [33m  silent = [34mfalse[39m[32m[33m,[39m[32m[39m
+[32m- [33m  onMouseOver,[39m[32m[39m
+[32m- [33m}) [39m[32m{[39m
+[32m-   [34mif[39m[32m (!greeting) {[39m
+[32m-     [34mreturn[39m[32m [34mnull[39m[32m;[39m
 [32m-   }[39m
-[31m+ [33m[34mfunction[31m[33m HelloWorld({greeting = [31m\\"hello\\"[31m[33m, greeted = [31m'\\"World\\"'[31m[33m, silent = false, onMouseOver,}) [31m{[39m
-[31m+ [39m
-[31m+   [34mif[31m(!greeting){[34mreturn[31m [34mnull[31m};[39m
-[31m+ [39m
-[31m+      [32m// [32mTODO:[31m[32m Don't use random in render[31m[39m
-[31m+   [34mlet[31m num = [36mMath[31m.floor ([36mMath[31m.random() * [32m1E+7[31m).toString().replace([31m/\\\\.\\\\d+/ig[31m, [31m\\"\\"[31m)[39m
-[31m+ [39m
-[31m+   [34mreturn[31m [90m<[34mdiv[31m[90m [36mclassName[31m[90m=[31m'HelloWorld'[31m[90m [36mtitle[31m[90m=[31m{[31m[90m\`[36mYou[31m[90m [36mare[31m[90m [36mvisitor[31m[90m [36mnumber[31m[90m \${ [36mnum[31m[90m }\`} [36monMouseOver[31m[90m=[31m{onMouseOver}[31m[90m>[31m[39m
-[31m+ [39m
-[31m+     [90m<[34mstrong[31m[90m>[31m{ greeting.slice( 0, 1 ).toUpperCase() + greeting.slice(1).toLowerCase() }[90m</[34mstrong[31m[90m>[31m[39m
-[31m+     {greeting.endsWith(\\",\\") ? \\" \\" : [90m<[34mspan[31m[90m [36mstyle[31m[90m=[31m{{color:[31m[90m '\\\\[36mgrey[31m[90m'}}>[31m\\", \\"[90m</[34mspan[31m[90m>[31m }[39m
-[31m+     [90m<[34mem[31m[90m>[31m[39m
+[31m+ [33m[34mfunction[39m[31m[33m HelloWorld({greeting = [31m\\"hello\\"[39m[31m[33m, greeted = [31m'\\"World\\"'[39m[31m[33m, silent = [34mfalse[39m[31m[33m, onMouseOver,}) [39m[31m{[39m
+[31m+[39m
+[31m+   [34mif[39m[31m(!greeting){[34mreturn[39m[31m [34mnull[39m[31m};[39m
+[31m+[39m
+[31m+      [32m// [32mTODO:[39m[31m[32m Don't use random in render[39m[31m[39m
+[31m+   [34mlet[39m[31m num = [36mMath[39m[31m.floor ([36mMath[39m[31m.random() * [32m1E+7[39m[31m).toString().replace([31m/\\\\.\\\\d+/ig[39m[31m, [31m\\"\\"[39m[31m)[39m
+[31m+[39m
+[31m+   [34mreturn[39m[31m [90m<[34mdiv[39m[31m[90m [36mclassName[39m[31m[90m=[31m'HelloWorld'[39m[31m[90m [36mtitle[39m[31m[90m=[31m{[39m[31m[90m\`[36mYou[39m[31m[90m [36mare[39m[31m[90m [36mvisitor[39m[31m[90m [36mnumber[39m[31m[90m \${ [36mnum[39m[31m[90m }\`} [36monMouseOver[39m[31m[90m=[31m{onMouseOver}[39m[31m[90m>[39m[31m[39m
+[31m+[39m
+[31m+     [90m<[34mstrong[39m[31m[90m>[39m[31m{ greeting.slice( 0, 1 ).toUpperCase() + greeting.slice(1).toLowerCase() }[90m</[34mstrong[39m[31m[90m>[39m[31m[39m
+[31m+     {greeting.endsWith(\\",\\") ? \\" \\" : [90m<[34mspan[39m[31m[90m [36mstyle[39m[31m[90m=[31m{{color:[39m[31m[90m '\\\\[36mgrey[39m[31m[90m'}}>[39m[31m\\", \\"[90m</[34mspan[39m[31m[90m>[39m[31m }[39m
+[31m+     [90m<[34mem[39m[31m[90m>[39m[31m[39m
 [31m+ 	{ greeted }[39m
-[31m+ 	[90m</[34mem[31m[90m>[31m[39m
+[31m+ 	[90m</[34mem[39m[31m[90m>[39m[31m[39m
 [31m+     { (silent)[39m
 [31m+       ? \\".\\"[39m
 [31m+       : \\"!\\"}[39m
-[2m  [22m
-[32m-   [32m// [32mTODO:[32m[32m Don't use random in render[32m[39m
-[32m-   [34mlet[32m num = [36mMath[32m.floor([36mMath[32m.random() * [32m1e7[32m)[39m
+
+[32m-   [32m// [32mTODO:[39m[32m[32m Don't use random in render[39m[32m[39m
+[32m-   [34mlet[39m[32m num = [36mMath[39m[32m.floor([36mMath[39m[32m.random() * [32m1e7[39m[32m)[39m
 [32m-     .toString()[39m
-[32m-     .replace([31m/\\\\.\\\\d+/gi[32m, [31m\\"\\"[32m);[39m
-[31m+     [90m</[34mdiv[31m[90m>[31m;[39m
-[2m  [22m
-[32m-   [34mreturn[32m ([39m
-[32m-     [90m<[34mdiv[32m[90m[32m[39m
-[32m- [90m      [36mclassName[32m[90m=[31m\\"HelloWorld\\"[32m[90m[32m[39m
-[32m- [90m      [36mtitle[32m[90m=[31m{[32m[90m\`[36mYou[32m[90m [36mare[32m[90m [36mvisitor[32m[90m [36mnumber[32m[90m \${[36mnum[32m[90m}\`}[32m[39m
-[32m- [90m      [36monMouseOver[32m[90m=[31m{onMouseOver}[32m[90m[32m[39m
-[32m- [90m    >[32m[39m
-[32m-       [90m<[34mstrong[32m[90m>[32m[39m
+[32m-     .replace([31m/\\\\.\\\\d+/gi[39m[32m, [31m\\"\\"[39m[32m);[39m
+[31m+     [90m</[34mdiv[39m[31m[90m>[39m[31m;[39m
+
+[32m-   [34mreturn[39m[32m ([39m
+[32m-     [90m<[34mdiv[39m[32m[90m[39m[32m[39m
+[32m- [90m      [36mclassName[39m[32m[90m=[31m\\"HelloWorld\\"[39m[32m[90m[39m[32m[39m
+[32m- [90m      [36mtitle[39m[32m[90m=[31m{[39m[32m[90m\`[36mYou[39m[32m[90m [36mare[39m[32m[90m [36mvisitor[39m[32m[90m [36mnumber[39m[32m[90m \${[36mnum[39m[32m[90m}\`}[39m[32m[39m
+[32m- [90m      [36monMouseOver[39m[32m[90m=[31m{onMouseOver}[39m[32m[90m[39m[32m[39m
+[32m- [90m    >[39m[32m[39m
+[32m-       [90m<[34mstrong[39m[32m[90m>[39m[32m[39m
 [32m-         {greeting.slice(0, 1).toUpperCase() + greeting.slice(1).toLowerCase()}[39m
-[32m-       [90m</[34mstrong[32m[90m>[32m[39m
+[32m-       [90m</[34mstrong[39m[32m[90m>[39m[32m[39m
 [32m-       {greeting.endsWith(\\",\\") ? ([39m
 [32m-         \\" \\"[39m
 [32m-       ) : ([39m
-[32m-         [90m<[34mspan[32m[90m [36mstyle[32m[90m=[31m{{[32m[90m [36mcolor:[32m[90m \\"[36mgrey[32m[90m\\" }}>[32m\\", \\"[90m</[34mspan[32m[90m>[32m[39m
+[32m-         [90m<[34mspan[39m[32m[90m [36mstyle[39m[32m[90m=[31m{{[39m[32m[90m [36mcolor:[39m[32m[90m \\"[36mgrey[39m[32m[90m\\" }}>[39m[32m\\", \\"[90m</[34mspan[39m[32m[90m>[39m[32m[39m
 [32m-       )}[39m
-[32m-       [90m<[34mem[32m[90m>[32m{greeted}[90m</[34mem[32m[90m>[32m[39m
+[32m-       [90m<[34mem[39m[32m[90m>[39m[32m{greeted}[90m</[34mem[39m[32m[90m>[39m[32m[39m
 [32m-       {silent ? \\".\\" : \\"!\\"}[39m
-[32m-     [90m</[34mdiv[32m[90m>[32m[39m
+[32m-     [90m</[34mdiv[39m[32m[90m>[39m[32m[39m
 [32m-   );[39m
 [2m  }[22m
-[32m- [39m",
+[32m-[39m",
       ],
       "fullName": undefined,
       "numPassingAsserts": 1,

--- a/src/run.js
+++ b/src/run.js
@@ -1,7 +1,7 @@
 const { highlight } = require("cli-highlight");
 const { pass, fail } = require("create-jest-runner");
 const fs = require("fs");
-const diff = require("jest-diff");
+const { diff } = require("jest-diff");
 const prettier = require("prettier");
 
 module.exports = ({ testPath }) => {

--- a/src/run.js
+++ b/src/run.js
@@ -8,9 +8,9 @@ module.exports = ({ testPath }) => {
   const start = new Date();
   const contents = fs.readFileSync(testPath, "utf8");
 
-  return prettier.resolveConfig(testPath).then(config => {
+  return prettier.resolveConfig(testPath).then((config) => {
     const prettierConfig = Object.assign({}, config, {
-      filepath: testPath
+      filepath: testPath,
     });
 
     const isPretty = prettier.check(contents, prettierConfig);
@@ -18,7 +18,7 @@ module.exports = ({ testPath }) => {
       return pass({
         start,
         end: new Date(),
-        test: { path: testPath }
+        test: { path: testPath },
       });
     }
 
@@ -30,9 +30,9 @@ module.exports = ({ testPath }) => {
       test: {
         path: testPath,
         errorMessage: diff(highlight(formatted), highlight(contents), {
-          expand: false
-        })
-      }
+          expand: false,
+        }),
+      },
     });
   });
 };

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -6,13 +6,13 @@ expect.addSnapshotSerializer({
   print: (value, serialize) => {
     delete value.perfStats;
     delete value.testFilePath;
-    value.testResults.forEach(result => {
+    value.testResults.forEach((result) => {
       delete result.duration;
     });
     return serialize(value);
   },
-  test: value =>
-    value && value.perfStats && value.testFilePath && value.testResults
+  test: (value) =>
+    value && value.perfStats && value.testFilePath && value.testResults,
 });
 
 describe("jest-runner-prettier", () => {
@@ -22,8 +22,8 @@ describe("jest-runner-prettier", () => {
         return run({
           testPath: path.join(__dirname, "__fixtures__", `good.json`),
           config: {},
-          globalConfig: {}
-        }).then(result => expect(result).toMatchSnapshot());
+          globalConfig: {},
+        }).then((result) => expect(result).toMatchSnapshot());
       });
     });
 
@@ -32,8 +32,8 @@ describe("jest-runner-prettier", () => {
         return run({
           testPath: path.join(__dirname, "__fixtures__", `bad.json`),
           config: {},
-          globalConfig: {}
-        }).then(result => expect(result).toMatchSnapshot());
+          globalConfig: {},
+        }).then((result) => expect(result).toMatchSnapshot());
       });
     });
   });
@@ -44,8 +44,8 @@ describe("jest-runner-prettier", () => {
         return run({
           testPath: path.join(__dirname, "__fixtures__", `good.jsx`),
           config: {},
-          globalConfig: {}
-        }).then(result => expect(result).toMatchSnapshot());
+          globalConfig: {},
+        }).then((result) => expect(result).toMatchSnapshot());
       });
     });
 
@@ -54,8 +54,8 @@ describe("jest-runner-prettier", () => {
         return run({
           testPath: path.join(__dirname, "__fixtures__", `bad.jsx`),
           config: {},
-          globalConfig: {}
-        }).then(result => expect(result).toMatchSnapshot());
+          globalConfig: {},
+        }).then((result) => expect(result).toMatchSnapshot());
       });
     });
   });

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -1,11 +1,11 @@
 const path = require("path");
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     mutate: [
       "src/**/*.js",
       "!src/**/*@(.test|.spec|Spec).js",
-      "!src/__fixtures__/**/*.ts"
+      "!src/__fixtures__/**/*.ts",
     ],
     mutator: "javascript",
     packageManager: "npm",
@@ -17,7 +17,7 @@ module.exports = function(config) {
       projectType: "custom",
       // Only use the unit test project
       config: require(path.resolve(__dirname, "./jest.config.js")).projects[0],
-      enableFindRelatedTests: true
-    }
+      enableFindRelatedTests: true,
+    },
   });
 };


### PR DESCRIPTION
jest with version 27 exports only a named export for the diff
function, so we had to fix the master branch here.

https://github.com/facebook/jest/blob/d38156ccd7a68e52372b4eb6fc02afbadd5b703e/packages/jest-diff/src/index.ts#L63
Co-authored-by: Björn Brauer <bjoern.brauer@new-work.se>