### PR TITLE
fix: blocklist Prettier 3 as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       },
       "peerDependencies": {
         "jest": ">= 27.0.0",
-        "prettier": ">= 1.8"
+        "prettier": ">= 1.8 < 3"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "jest": ">= 27.0.0",
-    "prettier": ">= 1.8"
+    "prettier": ">= 1.8 < 3"
   },
   "devDependencies": {
     "@commitlint/cli": "17.2.0",


### PR DESCRIPTION
For the time being, this runner is incompatible with Prettier 3 (#586).

This PR updates the `peerDependencies` to reflect that. Installers will get a warning if they're using Prettier 3.