### PR TITLE
fix!: update for compatibility with the new async APIs in Prettier 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,11 +20,12 @@
         "@types/node": "18.11.9",
         "eslint": "8.27.0",
         "eslint-config-starstuff": "1.5.14",
+        "eslint-plugin-prettier": "^5.0.0",
         "husky": "8.0.2",
         "jest": "29.3.1",
         "jest-runner-eslint": "1.1.0",
         "lint-staged": "13.0.3",
-        "prettier": "2.7.1",
+        "prettier": "^3.0.0",
         "ts-jest": "29.0.3",
         "typescript": "4.8.4"
       },
@@ -34,7 +35,7 @@
       },
       "peerDependencies": {
         "jest": ">= 27.0.0",
-        "prettier": ">= 1.8"
+        "prettier": ">= 3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1980,6 +1981,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgr/utils": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+      "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.3.0",
+        "is-glob": "^4.0.3",
+        "open": "^9.1.0",
+        "picocolors": "^1.0.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.19",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.19.tgz",
@@ -2782,6 +2809,27 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.44"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2856,6 +2904,21 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3362,6 +3425,162 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "dependencies": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/default-browser/node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/default-browser/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -3816,21 +4035,29 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
       "dev": true,
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/prettier"
       },
       "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
         "eslint-config-prettier": {
           "optional": true
         }
@@ -4350,15 +4577,15 @@
       "dev": true
     },
     "node_modules/fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4959,6 +5186,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4994,6 +5236,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-negative-zero": {
@@ -5134,6 +5394,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -7815,6 +8102,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -7957,6 +8262,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -8018,15 +8329,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -8384,6 +8695,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -8821,6 +9147,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/synckit/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -8862,6 +9210,18 @@
       "dev": true,
       "dependencies": {
         "readable-stream": "3"
+      }
+    },
+    "node_modules/titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tmpl": {
@@ -9095,6 +9455,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/uri-js": {
@@ -10770,6 +11139,28 @@
         "fastq": "^1.6.0"
       }
     },
+    "@pkgr/utils": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+      "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.3.0",
+        "is-glob": "^4.0.3",
+        "open": "^9.1.0",
+        "picocolors": "^1.0.0",
+        "tslib": "^2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.24.19",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.19.tgz",
@@ -11370,6 +11761,21 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true
+    },
+    "bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.44"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -11426,6 +11832,15 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true
+    },
+    "bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "requires": {
+        "run-applescript": "^5.0.0"
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -11804,6 +12219,101 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
+    "default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "requires": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+          "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^4.3.0",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+          "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
+        }
+      }
+    },
+    "default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "requires": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      }
+    },
+    "define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -12199,7 +12709,7 @@
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-jest": "^27.0.0",
         "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.3.0",
@@ -12248,12 +12758,13 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
       "dev": true,
       "requires": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       }
     },
     "eslint-plugin-promise": {
@@ -12495,15 +13006,15 @@
       "dev": true
     },
     "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -12938,6 +13449,12 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -12961,6 +13478,15 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
+      }
+    },
+    "is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^3.0.0"
       }
     },
     "is-negative-zero": {
@@ -13050,6 +13576,23 @@
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
+      }
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      },
+      "dependencies": {
+        "is-docker": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+          "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+          "dev": true
+        }
       }
     },
     "isexe": {
@@ -14981,6 +15524,18 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "requires": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -15079,6 +15634,12 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -15116,9 +15677,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -15367,6 +15928,15 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "requires": {
+        "execa": "^5.0.0"
       }
     },
     "run-parallel": {
@@ -15702,6 +16272,24 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
+    "synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "requires": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -15738,6 +16326,12 @@
       "requires": {
         "readable-stream": "3"
       }
+    },
+    "titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+      "dev": true
     },
     "tmpl": {
       "version": "1.0.5",
@@ -15877,6 +16471,12 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "husky install"
   },
   "lint-staged": {
-    "*": "node --experimental-vm-modules node_modules/jest/bin/jest.js --bail --findRelatedTests"
+    "src/*": "node --experimental-vm-modules node_modules/jest/bin/jest.js --bail --findRelatedTests"
   },
   "release": {
     "verifyConditions": "@semantic-release/github"
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "jest": ">= 27.0.0",
-    "prettier": ">= 1.8"
+    "prettier": ">= 3"
   },
   "devDependencies": {
     "@commitlint/cli": "17.2.0",
@@ -40,11 +40,12 @@
     "@types/node": "18.11.9",
     "eslint": "8.27.0",
     "eslint-config-starstuff": "1.5.14",
+    "eslint-plugin-prettier": "^5.0.0",
     "husky": "8.0.2",
     "jest": "29.3.1",
     "jest-runner-eslint": "1.1.0",
     "lint-staged": "13.0.3",
-    "prettier": "2.7.1",
+    "prettier": "^3.0.0",
     "ts-jest": "29.0.3",
     "typescript": "4.8.4"
   },
@@ -58,5 +59,10 @@
     "extends": [
       "@commitlint/config-conventional"
     ]
+  },
+  "overrides": {
+    "eslint-config-starstuff": {
+      "eslint-plugin-prettier": "^5.0.0"
+    }
   }
 }

--- a/src/__snapshots__/run.test.ts.snap
+++ b/src/__snapshots__/run.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-runner-prettier JSON bad fixture matches snapshot 1`] = `
-Object {
+{
   "console": undefined,
   "coverage": undefined,
   "displayName": undefined,
@@ -9,25 +9,25 @@ Object {
 [31m+ Received[39m
 
 [32m- {[39m
-[32m-   [33m\\"ohMyGodLongArray\\"[39m[32m: [[39m
-[32m-     [36m\\"prettyLongValue\\"[39m[32m,[39m
-[32m-     [36m\\"decentlyLongValue\\"[39m[32m,[39m
-[32m-     [36m\\"prettyDecentlyLongValue\\"[39m[32m,[39m
-[32m-     [36m\\"wowWowWowWhatALongValue\\"[39m[32m[39m
+[32m-   [33m"ohMyGodLongArray"[39m[32m: [[39m
+[32m-     [36m"prettyLongValue"[39m[32m,[39m
+[32m-     [36m"decentlyLongValue"[39m[32m,[39m
+[32m-     [36m"prettyDecentlyLongValue"[39m[32m,[39m
+[32m-     [36m"wowWowWowWhatALongValue"[39m[32m[39m
 [32m-   ],[39m
-[32m-   [33m\\"woahThisObjectIsDisapperingOffTheScreen\\"[39m[32m: {[39m
-[32m-     [33m\\"foo\\"[39m[32m: [36m\\"bar\\"[39m[32m,[39m
-[32m-     [33m\\"bar\\"[39m[32m: [36m\\"foo\\"[39m[32m,[39m
-[32m-     [33m\\"faz\\"[39m[32m: [32mfalse[39m[32m[39m
+[32m-   [33m"woahThisObjectIsDisapperingOffTheScreen"[39m[32m: {[39m
+[32m-     [33m"foo"[39m[32m: [36m"bar"[39m[32m,[39m
+[32m-     [33m"bar"[39m[32m: [36m"foo"[39m[32m,[39m
+[32m-     [33m"faz"[39m[32m: [32mfalse[39m[32m[39m
 [32m-   },[39m
-[32m-   [33m\\"truthy\\"[39m[32m: [32mtrue[39m[32m,[39m
-[32m-   [33m\\"aNumber\\"[39m[32m: [36m123[39m[32m,[39m
-[32m-   [33m\\"aString\\"[39m[32m: [36m\\"hi\\"[39m[32m[39m
+[32m-   [33m"truthy"[39m[32m: [32mtrue[39m[32m,[39m
+[32m-   [33m"aNumber"[39m[32m: [36m123[39m[32m,[39m
+[32m-   [33m"aString"[39m[32m: [36m"hi"[39m[32m[39m
 [32m- }[39m
 [32m-[39m
-[31m+ {[33m\\"ohMyGodLongArray\\"[39m[31m: [[36m\\"prettyLongValue\\"[39m[31m, [36m\\"decentlyLongValue\\"[39m[31m,[39m
-[31m+   [36m\\"prettyDecentlyLongValue\\"[39m[31m, [36m\\"wowWowWowWhatALongValue\\"[39m[31m], [33m\\"woahThisObjectIsDisapperingOffTheScreen\\"[39m[31m: {[33m\\"foo\\"[39m[31m: [36m\\"bar\\"[39m[31m,[39m
-[31m+     [33m\\"bar\\"[39m[31m: [36m\\"foo\\"[39m[31m, [33m\\"faz\\"[39m[31m: [32mfalse[39m[31m}, [33m\\"truthy\\"[39m[31m: [32mtrue[39m[31m, [33m\\"aNumber\\"[39m[31m: [36m123[39m[31m, [33m\\"aString\\"[39m[31m: [36m\\"hi\\"[39m[31m[39m
+[31m+ {[33m"ohMyGodLongArray"[39m[31m: [[36m"prettyLongValue"[39m[31m, [36m"decentlyLongValue"[39m[31m,[39m
+[31m+   [36m"prettyDecentlyLongValue"[39m[31m, [36m"wowWowWowWhatALongValue"[39m[31m], [33m"woahThisObjectIsDisapperingOffTheScreen"[39m[31m: {[33m"foo"[39m[31m: [36m"bar"[39m[31m,[39m
+[31m+     [33m"bar"[39m[31m: [36m"foo"[39m[31m, [33m"faz"[39m[31m: [32mfalse[39m[31m}, [33m"truthy"[39m[31m: [32mtrue[39m[31m, [33m"aNumber"[39m[31m: [36m123[39m[31m, [33m"aString"[39m[31m: [36m"hi"[39m[31m[39m
 [31m+   }[39m",
   "leaks": false,
   "memoryUsage": undefined,
@@ -35,46 +35,46 @@ Object {
   "numPassingTests": 0,
   "numPendingTests": 0,
   "numTodoTests": 0,
-  "openHandles": Array [],
+  "openHandles": [],
   "skipped": false,
-  "snapshot": Object {
+  "snapshot": {
     "added": 0,
     "fileDeleted": false,
     "matched": 0,
     "unchecked": 0,
-    "uncheckedKeys": Array [],
+    "uncheckedKeys": [],
     "unmatched": 0,
     "updated": 0,
   },
   "testExecError": undefined,
-  "testResults": Array [
-    Object {
-      "ancestorTitles": Array [],
-      "failureDetails": Array [],
-      "failureMessages": Array [
+  "testResults": [
+    {
+      "ancestorTitles": [],
+      "failureDetails": [],
+      "failureMessages": [
         "[32m- Expected[39m
 [31m+ Received[39m
 
 [32m- {[39m
-[32m-   [33m\\"ohMyGodLongArray\\"[39m[32m: [[39m
-[32m-     [36m\\"prettyLongValue\\"[39m[32m,[39m
-[32m-     [36m\\"decentlyLongValue\\"[39m[32m,[39m
-[32m-     [36m\\"prettyDecentlyLongValue\\"[39m[32m,[39m
-[32m-     [36m\\"wowWowWowWhatALongValue\\"[39m[32m[39m
+[32m-   [33m"ohMyGodLongArray"[39m[32m: [[39m
+[32m-     [36m"prettyLongValue"[39m[32m,[39m
+[32m-     [36m"decentlyLongValue"[39m[32m,[39m
+[32m-     [36m"prettyDecentlyLongValue"[39m[32m,[39m
+[32m-     [36m"wowWowWowWhatALongValue"[39m[32m[39m
 [32m-   ],[39m
-[32m-   [33m\\"woahThisObjectIsDisapperingOffTheScreen\\"[39m[32m: {[39m
-[32m-     [33m\\"foo\\"[39m[32m: [36m\\"bar\\"[39m[32m,[39m
-[32m-     [33m\\"bar\\"[39m[32m: [36m\\"foo\\"[39m[32m,[39m
-[32m-     [33m\\"faz\\"[39m[32m: [32mfalse[39m[32m[39m
+[32m-   [33m"woahThisObjectIsDisapperingOffTheScreen"[39m[32m: {[39m
+[32m-     [33m"foo"[39m[32m: [36m"bar"[39m[32m,[39m
+[32m-     [33m"bar"[39m[32m: [36m"foo"[39m[32m,[39m
+[32m-     [33m"faz"[39m[32m: [32mfalse[39m[32m[39m
 [32m-   },[39m
-[32m-   [33m\\"truthy\\"[39m[32m: [32mtrue[39m[32m,[39m
-[32m-   [33m\\"aNumber\\"[39m[32m: [36m123[39m[32m,[39m
-[32m-   [33m\\"aString\\"[39m[32m: [36m\\"hi\\"[39m[32m[39m
+[32m-   [33m"truthy"[39m[32m: [32mtrue[39m[32m,[39m
+[32m-   [33m"aNumber"[39m[32m: [36m123[39m[32m,[39m
+[32m-   [33m"aString"[39m[32m: [36m"hi"[39m[32m[39m
 [32m- }[39m
 [32m-[39m
-[31m+ {[33m\\"ohMyGodLongArray\\"[39m[31m: [[36m\\"prettyLongValue\\"[39m[31m, [36m\\"decentlyLongValue\\"[39m[31m,[39m
-[31m+   [36m\\"prettyDecentlyLongValue\\"[39m[31m, [36m\\"wowWowWowWhatALongValue\\"[39m[31m], [33m\\"woahThisObjectIsDisapperingOffTheScreen\\"[39m[31m: {[33m\\"foo\\"[39m[31m: [36m\\"bar\\"[39m[31m,[39m
-[31m+     [33m\\"bar\\"[39m[31m: [36m\\"foo\\"[39m[31m, [33m\\"faz\\"[39m[31m: [32mfalse[39m[31m}, [33m\\"truthy\\"[39m[31m: [32mtrue[39m[31m, [33m\\"aNumber\\"[39m[31m: [36m123[39m[31m, [33m\\"aString\\"[39m[31m: [36m\\"hi\\"[39m[31m[39m
+[31m+ {[33m"ohMyGodLongArray"[39m[31m: [[36m"prettyLongValue"[39m[31m, [36m"decentlyLongValue"[39m[31m,[39m
+[31m+   [36m"prettyDecentlyLongValue"[39m[31m, [36m"wowWowWowWhatALongValue"[39m[31m], [33m"woahThisObjectIsDisapperingOffTheScreen"[39m[31m: {[33m"foo"[39m[31m: [36m"bar"[39m[31m,[39m
+[31m+     [33m"bar"[39m[31m: [36m"foo"[39m[31m, [33m"faz"[39m[31m: [32mfalse[39m[31m}, [33m"truthy"[39m[31m: [32mtrue[39m[31m, [33m"aNumber"[39m[31m: [36m123[39m[31m, [33m"aString"[39m[31m: [36m"hi"[39m[31m[39m
 [31m+   }[39m",
       ],
       "fullName": "",
@@ -88,7 +88,7 @@ Object {
 `;
 
 exports[`jest-runner-prettier JSON good fixture matches snapshot 1`] = `
-Object {
+{
   "console": undefined,
   "coverage": undefined,
   "displayName": undefined,
@@ -99,23 +99,23 @@ Object {
   "numPassingTests": 1,
   "numPendingTests": 0,
   "numTodoTests": 0,
-  "openHandles": Array [],
+  "openHandles": [],
   "skipped": false,
-  "snapshot": Object {
+  "snapshot": {
     "added": 0,
     "fileDeleted": false,
     "matched": 0,
     "unchecked": 0,
-    "uncheckedKeys": Array [],
+    "uncheckedKeys": [],
     "unmatched": 0,
     "updated": 0,
   },
   "testExecError": undefined,
-  "testResults": Array [
-    Object {
-      "ancestorTitles": Array [],
-      "failureDetails": Array [],
-      "failureMessages": Array [],
+  "testResults": [
+    {
+      "ancestorTitles": [],
+      "failureDetails": [],
+      "failureMessages": [],
       "fullName": "",
       "numPassingAsserts": 1,
       "status": "passed",
@@ -127,7 +127,7 @@ Object {
 `;
 
 exports[`jest-runner-prettier JSX bad fixture matches snapshot 1`] = `
-Object {
+{
   "console": undefined,
   "coverage": undefined,
   "displayName": undefined,
@@ -135,54 +135,54 @@ Object {
 [31m+ Received[39m
 
 [32m- [32mfunction[39m[32m [34mHelloWorld[39m[32m({[39m
-[32m-   greeting = [36m\\"hello\\"[39m[32m,[39m
-[32m-   greeted = [36m'\\"World\\"'[39m[32m,[39m
+[32m-   greeting = [36m"hello"[39m[32m,[39m
+[32m-   greeted = [36m'"World"'[39m[32m,[39m
 [32m-   silent = [36mfalse[39m[32m,[39m
 [32m-   onMouseOver,[39m
 [32m- }) {[39m
 [32m-   [32mif[39m[32m (!greeting) {[39m
 [32m-     [32mreturn[39m[32m [36mnull[39m[32m;[39m
 [32m-   }[39m
-[31m+ [32mfunction[39m[31m [34mHelloWorld[39m[31m({greeting = [36m\\"hello\\"[39m[31m, greeted = [36m'\\"World\\"'[39m[31m, silent = [36mfalse[39m[31m, onMouseOver,}) {[39m
+[31m+ [32mfunction[39m[31m [34mHelloWorld[39m[31m({greeting = [36m"hello"[39m[31m, greeted = [36m'"World"'[39m[31m, silent = [36mfalse[39m[31m, onMouseOver,}) {[39m
 [31m+[39m
 [31m+   [32mif[39m[31m(!greeting){[32mreturn[39m[31m [36mnull[39m[31m};[39m
 [31m+[39m
 [31m+      [90m// [36mTODO:[39m[31m[90m Don't use random in render[39m[31m[39m
-[31m+   [32mlet[39m[31m num = [34mMath[39m[31m.floor ([34mMath[39m[31m.[34mrandom[39m[31m() * [36m1E+7[39m[31m).[34mtoString[39m[31m().[34mreplace[39m[31m([36m/\\\\.\\\\d+/ig[39m[31m, [36m\\"\\"[39m[31m)[39m
+[31m+   [32mlet[39m[31m num = [34mMath[39m[31m.floor ([34mMath[39m[31m.[34mrandom[39m[31m() * [36m1E+7[39m[31m).[34mtoString[39m[31m().[34mreplace[39m[31m([36m/\\.\\d+/ig[39m[31m, [36m""[39m[31m)[39m
 [31m+[39m
 [31m+   [32mreturn[39m[31m <[34mdiv[39m[31m [33mclassName[39m[31m=[36m'HelloWorld'[39m[31m [33mtitle[39m[31m=[36m{[39m[31m\`[33mYou[39m[31m [33mare[39m[31m [33mvisitor[39m[31m [33mnumber[39m[31m \${ [33mnum[39m[31m }\`} [33monMouseOver[39m[31m=[36m{onMouseOver}[39m[31m>[39m
 [31m+[39m
 [31m+     <[34mstrong[39m[31m>{ greeting.slice( 0, 1 ).toUpperCase() + greeting.slice(1).toLowerCase() }</[34mstrong[39m[31m>[39m
-[31m+     {greeting.endsWith(\\",\\") ? \\" \\" : <[34mspan[39m[31m [33mstyle[39m[31m=[36m{{color:[39m[31m '\\\\[33mgrey[39m[31m'}}>\\", \\"</[34mspan[39m[31m> }[39m
+[31m+     {greeting.endsWith(",") ? " " : <[34mspan[39m[31m [33mstyle[39m[31m=[36m{{color:[39m[31m '\\[33mgrey[39m[31m'}}>", "</[34mspan[39m[31m> }[39m
 [31m+     <[34mem[39m[31m>[39m
 [31m+ 	{ greeted }[39m
 [31m+ 	</[34mem[39m[31m>[39m
 [31m+     { (silent)[39m
-[31m+       ? \\".\\"[39m
-[31m+       : \\"!\\"}[39m
+[31m+       ? "."[39m
+[31m+       : "!"}[39m
 
 [32m-   [90m// [36mTODO:[39m[32m[90m Don't use random in render[39m[32m[39m
 [32m-   [32mlet[39m[32m num = [34mMath[39m[32m.[34mfloor[39m[32m([34mMath[39m[32m.[34mrandom[39m[32m() * [36m1e7[39m[32m)[39m
 [32m-     .[34mtoString[39m[32m()[39m
-[32m-     .[34mreplace[39m[32m([36m/\\\\.\\\\d+/gi[39m[32m, [36m\\"\\"[39m[32m);[39m
+[32m-     .[34mreplace[39m[32m([36m/\\.\\d+/gi[39m[32m, [36m""[39m[32m);[39m
 [31m+     </[34mdiv[39m[31m>;[39m
 
 [32m-   [32mreturn[39m[32m ([39m
 [32m-     <[34mdiv[39m[32m[39m
-[32m-       [33mclassName[39m[32m=[36m\\"HelloWorld\\"[39m[32m[39m
+[32m-       [33mclassName[39m[32m=[36m"HelloWorld"[39m[32m[39m
 [32m-       [33mtitle[39m[32m=[36m{[39m[32m\`[33mYou[39m[32m [33mare[39m[32m [33mvisitor[39m[32m [33mnumber[39m[32m \${[33mnum[39m[32m}\`}[39m
 [32m-       [33monMouseOver[39m[32m=[36m{onMouseOver}[39m[32m[39m
 [32m-     >[39m
 [32m-       <[34mstrong[39m[32m>[39m
 [32m-         {greeting.slice(0, 1).toUpperCase() + greeting.slice(1).toLowerCase()}[39m
 [32m-       </[34mstrong[39m[32m>[39m
-[32m-       {greeting.endsWith(\\",\\") ? ([39m
-[32m-         \\" \\"[39m
+[32m-       {greeting.endsWith(",") ? ([39m
+[32m-         " "[39m
 [32m-       ) : ([39m
-[32m-         <[34mspan[39m[32m [33mstyle[39m[32m=[36m{{[39m[32m [33mcolor:[39m[32m \\"[33mgrey[39m[32m\\" }}>\\", \\"</[34mspan[39m[32m>[39m
+[32m-         <[34mspan[39m[32m [33mstyle[39m[32m=[36m{{[39m[32m [33mcolor:[39m[32m "[33mgrey[39m[32m" }}>", "</[34mspan[39m[32m>[39m
 [32m-       )}[39m
 [32m-       <[34mem[39m[32m>{greeted}</[34mem[39m[32m>[39m
-[32m-       {silent ? \\".\\" : \\"!\\"}[39m
+[32m-       {silent ? "." : "!"}[39m
 [32m-     </[34mdiv[39m[32m>[39m
 [32m-   );[39m
 [2m  }[22m
@@ -193,75 +193,75 @@ Object {
   "numPassingTests": 0,
   "numPendingTests": 0,
   "numTodoTests": 0,
-  "openHandles": Array [],
+  "openHandles": [],
   "skipped": false,
-  "snapshot": Object {
+  "snapshot": {
     "added": 0,
     "fileDeleted": false,
     "matched": 0,
     "unchecked": 0,
-    "uncheckedKeys": Array [],
+    "uncheckedKeys": [],
     "unmatched": 0,
     "updated": 0,
   },
   "testExecError": undefined,
-  "testResults": Array [
-    Object {
-      "ancestorTitles": Array [],
-      "failureDetails": Array [],
-      "failureMessages": Array [
+  "testResults": [
+    {
+      "ancestorTitles": [],
+      "failureDetails": [],
+      "failureMessages": [
         "[32m- Expected[39m
 [31m+ Received[39m
 
 [32m- [32mfunction[39m[32m [34mHelloWorld[39m[32m({[39m
-[32m-   greeting = [36m\\"hello\\"[39m[32m,[39m
-[32m-   greeted = [36m'\\"World\\"'[39m[32m,[39m
+[32m-   greeting = [36m"hello"[39m[32m,[39m
+[32m-   greeted = [36m'"World"'[39m[32m,[39m
 [32m-   silent = [36mfalse[39m[32m,[39m
 [32m-   onMouseOver,[39m
 [32m- }) {[39m
 [32m-   [32mif[39m[32m (!greeting) {[39m
 [32m-     [32mreturn[39m[32m [36mnull[39m[32m;[39m
 [32m-   }[39m
-[31m+ [32mfunction[39m[31m [34mHelloWorld[39m[31m({greeting = [36m\\"hello\\"[39m[31m, greeted = [36m'\\"World\\"'[39m[31m, silent = [36mfalse[39m[31m, onMouseOver,}) {[39m
+[31m+ [32mfunction[39m[31m [34mHelloWorld[39m[31m({greeting = [36m"hello"[39m[31m, greeted = [36m'"World"'[39m[31m, silent = [36mfalse[39m[31m, onMouseOver,}) {[39m
 [31m+[39m
 [31m+   [32mif[39m[31m(!greeting){[32mreturn[39m[31m [36mnull[39m[31m};[39m
 [31m+[39m
 [31m+      [90m// [36mTODO:[39m[31m[90m Don't use random in render[39m[31m[39m
-[31m+   [32mlet[39m[31m num = [34mMath[39m[31m.floor ([34mMath[39m[31m.[34mrandom[39m[31m() * [36m1E+7[39m[31m).[34mtoString[39m[31m().[34mreplace[39m[31m([36m/\\\\.\\\\d+/ig[39m[31m, [36m\\"\\"[39m[31m)[39m
+[31m+   [32mlet[39m[31m num = [34mMath[39m[31m.floor ([34mMath[39m[31m.[34mrandom[39m[31m() * [36m1E+7[39m[31m).[34mtoString[39m[31m().[34mreplace[39m[31m([36m/\\.\\d+/ig[39m[31m, [36m""[39m[31m)[39m
 [31m+[39m
 [31m+   [32mreturn[39m[31m <[34mdiv[39m[31m [33mclassName[39m[31m=[36m'HelloWorld'[39m[31m [33mtitle[39m[31m=[36m{[39m[31m\`[33mYou[39m[31m [33mare[39m[31m [33mvisitor[39m[31m [33mnumber[39m[31m \${ [33mnum[39m[31m }\`} [33monMouseOver[39m[31m=[36m{onMouseOver}[39m[31m>[39m
 [31m+[39m
 [31m+     <[34mstrong[39m[31m>{ greeting.slice( 0, 1 ).toUpperCase() + greeting.slice(1).toLowerCase() }</[34mstrong[39m[31m>[39m
-[31m+     {greeting.endsWith(\\",\\") ? \\" \\" : <[34mspan[39m[31m [33mstyle[39m[31m=[36m{{color:[39m[31m '\\\\[33mgrey[39m[31m'}}>\\", \\"</[34mspan[39m[31m> }[39m
+[31m+     {greeting.endsWith(",") ? " " : <[34mspan[39m[31m [33mstyle[39m[31m=[36m{{color:[39m[31m '\\[33mgrey[39m[31m'}}>", "</[34mspan[39m[31m> }[39m
 [31m+     <[34mem[39m[31m>[39m
 [31m+ 	{ greeted }[39m
 [31m+ 	</[34mem[39m[31m>[39m
 [31m+     { (silent)[39m
-[31m+       ? \\".\\"[39m
-[31m+       : \\"!\\"}[39m
+[31m+       ? "."[39m
+[31m+       : "!"}[39m
 
 [32m-   [90m// [36mTODO:[39m[32m[90m Don't use random in render[39m[32m[39m
 [32m-   [32mlet[39m[32m num = [34mMath[39m[32m.[34mfloor[39m[32m([34mMath[39m[32m.[34mrandom[39m[32m() * [36m1e7[39m[32m)[39m
 [32m-     .[34mtoString[39m[32m()[39m
-[32m-     .[34mreplace[39m[32m([36m/\\\\.\\\\d+/gi[39m[32m, [36m\\"\\"[39m[32m);[39m
+[32m-     .[34mreplace[39m[32m([36m/\\.\\d+/gi[39m[32m, [36m""[39m[32m);[39m
 [31m+     </[34mdiv[39m[31m>;[39m
 
 [32m-   [32mreturn[39m[32m ([39m
 [32m-     <[34mdiv[39m[32m[39m
-[32m-       [33mclassName[39m[32m=[36m\\"HelloWorld\\"[39m[32m[39m
+[32m-       [33mclassName[39m[32m=[36m"HelloWorld"[39m[32m[39m
 [32m-       [33mtitle[39m[32m=[36m{[39m[32m\`[33mYou[39m[32m [33mare[39m[32m [33mvisitor[39m[32m [33mnumber[39m[32m \${[33mnum[39m[32m}\`}[39m
 [32m-       [33monMouseOver[39m[32m=[36m{onMouseOver}[39m[32m[39m
 [32m-     >[39m
 [32m-       <[34mstrong[39m[32m>[39m
 [32m-         {greeting.slice(0, 1).toUpperCase() + greeting.slice(1).toLowerCase()}[39m
 [32m-       </[34mstrong[39m[32m>[39m
-[32m-       {greeting.endsWith(\\",\\") ? ([39m
-[32m-         \\" \\"[39m
+[32m-       {greeting.endsWith(",") ? ([39m
+[32m-         " "[39m
 [32m-       ) : ([39m
-[32m-         <[34mspan[39m[32m [33mstyle[39m[32m=[36m{{[39m[32m [33mcolor:[39m[32m \\"[33mgrey[39m[32m\\" }}>\\", \\"</[34mspan[39m[32m>[39m
+[32m-         <[34mspan[39m[32m [33mstyle[39m[32m=[36m{{[39m[32m [33mcolor:[39m[32m "[33mgrey[39m[32m" }}>", "</[34mspan[39m[32m>[39m
 [32m-       )}[39m
 [32m-       <[34mem[39m[32m>{greeted}</[34mem[39m[32m>[39m
-[32m-       {silent ? \\".\\" : \\"!\\"}[39m
+[32m-       {silent ? "." : "!"}[39m
 [32m-     </[34mdiv[39m[32m>[39m
 [32m-   );[39m
 [2m  }[22m
@@ -278,7 +278,7 @@ Object {
 `;
 
 exports[`jest-runner-prettier JSX good fixture matches snapshot 1`] = `
-Object {
+{
   "console": undefined,
   "coverage": undefined,
   "displayName": undefined,
@@ -289,23 +289,23 @@ Object {
   "numPassingTests": 1,
   "numPendingTests": 0,
   "numTodoTests": 0,
-  "openHandles": Array [],
+  "openHandles": [],
   "skipped": false,
-  "snapshot": Object {
+  "snapshot": {
     "added": 0,
     "fileDeleted": false,
     "matched": 0,
     "unchecked": 0,
-    "uncheckedKeys": Array [],
+    "uncheckedKeys": [],
     "unmatched": 0,
     "updated": 0,
   },
   "testExecError": undefined,
-  "testResults": Array [
-    Object {
-      "ancestorTitles": Array [],
-      "failureDetails": Array [],
-      "failureMessages": Array [],
+  "testResults": [
+    {
+      "ancestorTitles": [],
+      "failureDetails": [],
+      "failureMessages": [],
       "fullName": "",
       "numPassingAsserts": 1,
       "status": "passed",

--- a/src/run.ts
+++ b/src/run.ts
@@ -19,7 +19,7 @@ export default async ({ testPath }: Parameters): Promise<TestResult> => {
     filepath: testPath,
   };
 
-  const isPretty = prettier.check(contents, prettierConfig);
+  const isPretty = await prettier.check(contents, prettierConfig);
   if (isPretty) {
     return pass({
       start,
@@ -28,7 +28,7 @@ export default async ({ testPath }: Parameters): Promise<TestResult> => {
     });
   }
 
-  const formatted = prettier.format(contents, prettierConfig);
+  const formatted = await prettier.format(contents, prettierConfig);
 
   return fail({
     start,
@@ -40,7 +40,7 @@ export default async ({ testPath }: Parameters): Promise<TestResult> => {
         emphasize.highlightAuto(contents).value,
         {
           expand: false,
-        }
+        },
       ) as string | undefined,
     },
   });


### PR DESCRIPTION
This PR:

* pins the `peerDependencies` version of Prettier to >=3
* updates the callsites of the Prettier API to reflect the fact that they're now async

This is a breaking version that will require a major version bump.

Fixes #586.